### PR TITLE
Fix parseBMP assuming pixel data starts directly after header

### DIFF
--- a/Codec/BMP.hs
+++ b/Codec/BMP.hs
@@ -112,11 +112,11 @@ parseBMP2 buf fileHeader
  = let  -- Next comes the image header. 
         -- The first word tells us how long it is.
         sizeHeader      = runGet getWord32le buf
-        
+
         -- split off the image header
-        (bufImageHeader, bufRest)
-                = BSL.splitAt (fromIntegral sizeHeader) buf
-        
+        bufImageHeader
+                = BSL.take (fromIntegral sizeHeader) buf
+        bufRest = BSL.drop (fromIntegral (fromIntegral (fileHeaderOffset fileHeader) - sizeOfFileHeader)) buf
         -- How much non-header data is present in the file.
         -- For uncompressed data without a colour table, the remaining data
         -- should be the image, but there may also be padding bytes on the


### PR DESCRIPTION
parseBMP assumed the pixel data started directly after the BIP header instead of using the header offset value. 
A bmp can have data after the header which would be interpreted as pixel data by parseBMP. 